### PR TITLE
fix nullpointer in ulTransmissionMap_ after node deletion

### DIFF
--- a/src/common/binder/Binder.cc
+++ b/src/common/binder/Binder.cc
@@ -162,7 +162,7 @@ void Binder::unregisterNode(MacNodeId id)
         mac->unregisterHarqBufferRx(id);
     }
 
-    // remove 'id' from LteMacBase* cache but do not delte pointer.
+    // remove 'id' from LteMacBase* cache but do not delete pointer.
     if(macNodeIdToModule_.erase(id) != 1){
         EV_ERROR << "Cannot unregister node - node id \"" << id << "\" - not found";
     }
@@ -170,6 +170,21 @@ void Binder::unregisterNode(MacNodeId id)
     // remove 'id' from MacNodeId mapping
     if(nodeIds_.erase(id) != 1){
         EV_ERROR << "Cannot unregister node - node id \"" << id << "\" - not found";
+    }
+    // remove 'id' from ulTransmissionMap_ if currently scheduled
+    for(auto &carrier : ulTransmissionMap_){ // all carrier frequency
+        for(auto &bands : carrier.second){ // all RB's for current and last TTI (vector<vector<vector<UeAllocationInfo>>>)
+            for(auto &ues : bands){ // all Ue's in each block
+                auto itr = ues.begin();
+                while(itr != ues.end()){
+                    if (itr->nodeId == id){
+                        itr = ues.erase(itr);
+                    } else {
+                        itr++;
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
The `ulTransmissionMap_` map managed by the Binder.cc can contain pointers to deleted physical layer objects.

If a node sent data in the last TTI it will be held in the transmission map. If this node then leaves the simulation all 
models of this nodes will be deleted. However the reference in the `ulTransmissionMap_` will not be deleted until
 the next TTI. Thus in cases (rare) where a node is deleted between two TTI's and the deleted node sent something 
in the last TTI any other node which access the `ulTransmissionMap_` can produce a segmentation fault. 

Proposed (Simple) Solution:

Each node class the `unregisterNode` method of the Binder prior of deletion. Check here if the node is in the 
`ulTransmissionMap_` and remove the node. This will of course reduce the interference calculation. 

