### PR TITLE
add std::enld to logging statement to fix omnetpp gui log filtering

### DIFF
--- a/src/stack/phy/layer/LtePhyUeD2D.cc
+++ b/src/stack/phy/layer/LtePhyUeD2D.cc
@@ -428,13 +428,13 @@ void LtePhyUeD2D::storeAirFrame(LteAirFrame* newFrame)
         }
         if (allocatedRbs > 0)
             rsrpMean = sum / allocatedRbs;
-        EV << NOW << " LtePhyUeD2D::storeAirFrame - Average RSRP from node " << newInfo->getSourceId() << ": " << rsrpMean ;
+        EV << NOW << " LtePhyUeD2D::storeAirFrame - Average RSRP from node " << newInfo->getSourceId() << ": " << rsrpMean << endl;
     }
     else  // distance
     {
         Coord newSenderCoord = newInfo->getCoord();
         distance = myCoord.distance(newSenderCoord);
-        EV << NOW << " LtePhyUeD2D::storeAirFrame - Distance from node " << newInfo->getSourceId() << ": " << distance ;
+        EV << NOW << " LtePhyUeD2D::storeAirFrame - Distance from node " << newInfo->getSourceId() << ": " << distance << endl;
     }
 
     if (!d2dReceivedFrames_.empty())


### PR DESCRIPTION
Using the OMNeT++ GUI (Qtenv) it is possible to see the log statements only for the selected module. 

However some logging information of the LtePhyUe bleeds into the output making it hard to see the selected modules log statemets.

Adding `<< std::endl;` to the log statements in LetPhyUeD2D.cc does the trick.
