### PR TITLE
Minor fixes: cars scenarios, channelModel configuration in d2d/d2d_multihop

### DIFF
--- a/simulations/NR/cars/Highway.ned
+++ b/simulations/NR/cars/Highway.ned
@@ -10,6 +10,7 @@
 //
 package simu5g.simulations.NR.cars;
 
+import inet.networklayer.configurator.ipv4.Ipv4NetworkConfigurator;
 import inet.networklayer.ipv4.RoutingTableRecorder;
 import inet.node.inet.AdhocHost;
 import inet.node.inet.Router;
@@ -18,7 +19,6 @@ import inet.node.ethernet.Eth10G;
 
 import simu5g.world.radio.LteChannelControl;
 import simu5g.common.carrierAggregation.CarrierAggregation;
-import simu5g.common.CellularNetworkConfigurator;
 import simu5g.nodes.Upf;
 import simu5g.common.binder.Binder;
 import simu5g.nodes.NR.gNodeB;
@@ -39,7 +39,7 @@ network Highway
         routingRecorder: RoutingTableRecorder {
             @display("p=50,75;is=s");
         }
-        configurator: CellularNetworkConfigurator {
+        configurator: Ipv4NetworkConfigurator {
             @display("p=50,125");
             config = xmldoc("demo.xml");
         }

--- a/simulations/cars/Highway.ned
+++ b/simulations/cars/Highway.ned
@@ -10,6 +10,7 @@
 //
 package simu5g.simulations.cars;
 
+import inet.networklayer.configurator.ipv4.Ipv4NetworkConfigurator;
 import inet.networklayer.ipv4.RoutingTableRecorder;
 import inet.node.inet.AdhocHost;
 import inet.node.inet.Router;
@@ -18,7 +19,6 @@ import inet.node.ethernet.Eth10G;
 
 import simu5g.world.radio.LteChannelControl;
 import simu5g.common.carrierAggregation.CarrierAggregation;
-import simu5g.common.CellularNetworkConfigurator;
 import simu5g.nodes.PgwStandard;
 import simu5g.common.binder.Binder;
 import simu5g.nodes.eNodeB;
@@ -40,7 +40,7 @@ network Highway
         routingRecorder: RoutingTableRecorder {
             @display("p=50,75;is=s");
         }
-        configurator: CellularNetworkConfigurator {
+        configurator: Ipv4NetworkConfigurator {
             @display("p=50,125");
         }
 

--- a/simulations/d2d/omnetpp.ini
+++ b/simulations/d2d/omnetpp.ini
@@ -371,8 +371,8 @@ warmup-period=0s
 # 
 # Fading and shadowing are disabled to highlight the effects of mode switching
 # 
-**.cellularNic.channelModel.fading = false
-**.cellularNic.channelModel.shadowing = false
+**.cellularNic.channelModel[0].fading = false
+**.cellularNic.channelModel[0].shadowing = false
 
 ### eNodeBs configuration ###
 *.eNB.mobility.initFromDisplayString = false

--- a/simulations/d2d_multihop/omnetpp.ini
+++ b/simulations/d2d_multihop/omnetpp.ini
@@ -114,8 +114,8 @@ extends=MultihopD2D
 *.ue*[*].mobility.r = 1m
 *.ue*[*].mobility.speed = 1 mps
 																						
-**.cellularNic.channelModel.fading = ${fading = false , true }
-**.cellularNic.channelModel.shadowing = ${shadowing = false , true }
+**.cellularNic.channelModel[0].fading = ${fading = false , true }
+**.cellularNic.channelModel[0].shadowing = ${shadowing = false , true }
 
 output-scalar-file = ${resultdir}/${configname}/${iterationvars}-${repetition}-${runid}.sca
 output-vector-file = ${resultdir}/${configname}/${iterationvars}-${repetition}-${runid}.vec

--- a/tests/fingerprint/d2d_multihop.csv
+++ b/tests/fingerprint/d2d_multihop.csv
@@ -1,6 +1,6 @@
 # workingdir, args, simtimelimit, fingerprint
 /simulations/d2d_multihop/, -f omnetpp.ini -c MultihopD2D -r 0, 3s, afc6-21e3/tplx, PASS,
 /simulations/d2d_multihop/, -f omnetpp.ini -c MultihopD2D-Trickle -r 0, 3s, 2ff5-ba97/tplx, PASS,
-/simulations/d2d_multihop/, -f omnetpp.ini -c MultihopD2D-rangeCheck -r 0, 3s, d642-3016/tplx, PASS,
-/simulations/d2d_multihop/, -f omnetpp.ini -c MultihopD2D-rangeCheckTrickle -r 0, 3s, beda-7952/tplx, PASS,
+/simulations/d2d_multihop/, -f omnetpp.ini -c MultihopD2D-rangeCheck -r 0, 3s, 82b0-5442/tplx, PASS,
+/simulations/d2d_multihop/, -f omnetpp.ini -c MultihopD2D-rangeCheckTrickle -r 0, 3s, 45c1-db52/tplx, PASS,
 


### PR DESCRIPTION
This pull request includes two small fixes to the current master:
1. within the cars scenarios (LTE and 5G) the CellularNetworkConfigurator was still used - not necessary anymore since in INET 4.4.0 the wireless interfaces are recognized by isWireless()
2. in d2d and d2d_multihop, the channelModel configuration was not set correctly - since Simu5G it is an array of channelModel configurations