### PR TITLE
Fix: Usage of Simu5G components inside compound modules

### DIFF
--- a/src/corenetwork/gtp/GtpUser.cc
+++ b/src/corenetwork/gtp/GtpUser.cc
@@ -269,7 +269,8 @@ void GtpUser::handleFromUdp(Packet * pkt)
 
             // check if the destination belongs to the same core network (for multi-operator scenarios)
             const char* destGw = binder_->getModuleByMacNodeId(destMaster)->par("gateway");
-            if (strcmp(this->getParentModule()->getFullName(), destGw) == 0)
+            // Modified to make it work when used into compound modules
+            if (strcmp(this->getParentModule()->getFullPath().c_str(), destGw) == 0)
             {
                 // the destination is a Base Station under the same core network as this PGW/UPF,
                 // tunnel the packet toward that BS

--- a/src/corenetwork/trafficFlowFilter/TrafficFlowFilter.cc
+++ b/src/corenetwork/trafficFlowFilter/TrafficFlowFilter.cc
@@ -220,7 +220,7 @@ TrafficFlowTemplateId TrafficFlowFilter::findTrafficFlow(L3Address srcAddress, L
 
 void TrafficFlowFilter::finish() {
 	 if (ownerType_ == PGW || ownerType_ == UPF) {
-		 delete gateway_;
+		 delete[] gateway_;
 	 }
 }
 

--- a/src/corenetwork/trafficFlowFilter/TrafficFlowFilter.cc
+++ b/src/corenetwork/trafficFlowFilter/TrafficFlowFilter.cc
@@ -34,7 +34,9 @@ void TrafficFlowFilter::initialize(int stage)
     ownerType_ = selectOwnerType(par("ownerType"));
     if (ownerType_ == PGW || ownerType_ == UPF)
     {
-        gateway_ = getParentModule()->getFullName();
+    	// Modified from getFullName() to getFullPath() to fix the usage in compound modules
+    	std::string tmpName = getParentModule()->getFullPath();
+    	gateway_ = strcpy(new char[tmpName.length() + 1], tmpName.c_str());
     }
     else if(getParentModule()->hasPar("gateway") || getParentModule()->getParentModule()->hasPar("gateway"))
     {
@@ -214,5 +216,11 @@ TrafficFlowTemplateId TrafficFlowFilter::findTrafficFlow(L3Address srcAddress, L
 
     EV << "Forward packet to BS " << destMaster << endl;
     return destMaster;
+}
+
+void TrafficFlowFilter::finish() {
+	 if (ownerType_ == PGW || ownerType_ == UPF) {
+		 delete gateway_;
+	 }
 }
 

--- a/src/corenetwork/trafficFlowFilter/TrafficFlowFilter.h
+++ b/src/corenetwork/trafficFlowFilter/TrafficFlowFilter.h
@@ -68,6 +68,8 @@ class TrafficFlowFilter : public omnetpp::cSimpleModule
 
     // functions for managing filter tables
     TrafficFlowTemplateId findTrafficFlow(inet::L3Address srcAddress, inet::L3Address destAddress);
+
+    virtual void finish() override;
 };
 
 #endif

--- a/src/stack/mac/layer/LteMacEnb.cc
+++ b/src/stack/mac/layer/LteMacEnb.cc
@@ -191,7 +191,9 @@ void LteMacEnb::initialize(int stage)
 
         // register the pairs <id,name> and <id, module> to the binder
         cModule* module = getParentModule()->getParentModule();
-        const char* moduleName = getParentModule()->getParentModule()->getFullName();
+        // Modified from getFullName() to getFullPath() to fix the usage in compound modules
+        std::string tmpName = getParentModule()->getParentModule()->getFullPath();
+        const char* moduleName = strcpy(new char[tmpName.length() + 1], tmpName.c_str());
         binder_->registerName(nodeId_, moduleName);
         binder_->registerModule(nodeId_, module);
 


### PR DESCRIPTION
These changes aim to fix some errors found when using the Simu5G components inside compound modules. 
In the original version, there were some issues when trying to find the specified module using just the `getFullName()` method instead of the `getFullPath()`.
Changed this behavior in the `GptUser`, `TrafficFlowFilter` (where I also added some code to free the allocated memory at the end of the simulation) and in the `LteMacEnb` modules.

Now for all the _gnbs_ the value of the parameter _gateway_ must be specified using the full path of the gateway module as in the following example (we suppose that the top level network is called 'Network'):
Before
`**.gnb.gateway = "upf"`
Now:
`**.gnb.gateway = "Network.upf"` 

I dont't know if it is better to let the user specify it every time or implement some code that adds the network name at runtime when the gateway name specified implicitly refer to the top level (like the first one).