### PR TITLE
fix: drop data packets if not associated with eNB in sidelink.

### DIFF
--- a/src/stack/phy/layer/LtePhyUeD2D.cc
+++ b/src/stack/phy/layer/LtePhyUeD2D.cc
@@ -175,6 +175,15 @@ void LtePhyUeD2D::handleAirFrame(cMessage* msg)
 
     // this is a DATA packet
 
+    if (masterId_ == 0){
+        // UE is not (anymore) associated with any eNB/gNB and all harqBuffers are already deleted.
+        // Handing this data packet to the MAC layer will lead to null pointers.
+        EV << "LtePhyUeD2D: UE "<< nodeId_ << " received data packet while not associated to any base station. (masterId " << masterId_ << "). Drop it." << endl;
+        delete lteInfo;
+        delete frame;
+        return;
+    }
+
     // if the packet is a D2D multicast one, store it and decode it at the end of the TTI
     if (d2dMulticastEnableCaptureEffect_ && binder_->isInMulticastGroup(nodeId_,lteInfo->getMulticastGroupId()))
     {


### PR DESCRIPTION
Do not propagate received data packets up the stack when UE is NOT associated with an eNB anymore.

This can happen when handovers are active and a UE leaves a eNB but cannot attach to a new one. In this
case the UE is `assosicated` with a dummy master_Id of zero which does not have any data, leading to nullpointers
in the mac layer processing
