### PR TITLE
fix: Allow re-association after connection loss with eNB.

### DIFF
--- a/src/stack/phy/layer/LtePhyUe.cc
+++ b/src/stack/phy/layer/LtePhyUe.cc
@@ -26,6 +26,7 @@ LtePhyUe::LtePhyUe()
     handoverTrigger_ = nullptr;
     cqiDlSum_ = cqiUlSum_ = 0;
     cqiDlCount_ = cqiUlCount_ = 0;
+    masterId_ = 0;
 }
 
 LtePhyUe::~LtePhyUe()
@@ -340,7 +341,11 @@ void LtePhyUe::handoverHandler(LteAirFrame* frame, UserControlInfo* lteInfo)
                 if (candidateMasterId_ == masterId_)  // trigger detachment
                 {
                     candidateMasterId_ = 0;
-                    candidateMasterRssi_ = 0;
+                    currentMasterRssi_ = -999.0;
+                    candidateMasterRssi_ = -999.0; // set candidate rssi very bad we currently do not have any.
+                                                   // this ensures that each candidate with is at least as 'bad'
+                                                   // as the minRssi_ has a change.
+
                     hysteresisTh_ = updateHysteresisTh(0);
                     binder_->addHandoverTriggered(nodeId_, masterId_, candidateMasterId_);
 


### PR DESCRIPTION
If no candidate eNB has more Rssi than rssi_min the UE is removed from the eNB and the masterId is set to 0 (i.e. not connected). The candidateMasterRssi_ must not be set to 0 in this case as this implies a really good connection RSSI to the cell with the masterId 0, which does not exist and is a placeholder for 'not connected'. Setting the candidateMassterRssi_ to 0 would not allow any re-assocation to any other eNB as no eNB will have  RSSSI > 0 (db/dbm). Thus setting the candidateMasterRssi_ to a small value.